### PR TITLE
Fix class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,30 +33,16 @@ Unit tests are performed on the following browsers:
 *   Safari 12.0
 *   Opera 60.0
  
-## Examples
-
-### Example written in JavaScript
+## Example
 
 Import readable-web-stream-to-node in JavaScript:
-```javascript
-const ReadableWeToNodeStream = require('readable-web-to-node-stream').ReadableWeToNodeStream;
+```js
+const {ReadableWebToNodeStream} = require('readable-web-to-node-stream');
 
 async function download(url) {
     const response = await fetch(url);
     const readableWebStream = response.body;
-    const nodeStream = new ReadableWeToNodeStream(readableWebStream);
-}
-```
-
-### Example written in TypeScript
-
-```TypeScript
-import { ReadableWeToNodeStream } from 'readable-web-to-node-stream';
-
-async function download(url) {
-  const response = await fetch(url);
-  const readableWebStream = response.body;
-  const nodeStream = new ReadableWeToNodeStream(readableWebStream);
+    const nodeStream = new ReadableWebToNodeStream(readableWebStream);
 }
 ```
 

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -2,7 +2,7 @@ localStorage.debug = 'readable-web-to-node-stream';
 
 import * as assert from 'assert';
 import * as mmb from 'music-metadata-browser';
-import { ReadableWeToNodeStream } from './index';
+import { ReadableWebToNodeStream } from './index';
 
 async function httpGetByUrl(url: string): Promise<Response> {
   const response = await fetch(url);
@@ -16,7 +16,7 @@ async function httpGetByUrl(url: string): Promise<Response> {
 }
 
 export async function parseReadableStream(stream: ReadableStream, contentType, options?: mmb.IOptions): Promise<mmb.IAudioMetadata> {
-  const ns = new ReadableWeToNodeStream(stream);
+  const ns = new ReadableWebToNodeStream(stream);
   const res = await mmb.parseNodeStream(ns, contentType, options);
   await ns.close();
   return res;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import { Readable } from 'stream';
  * Web API readable-stream: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
  * Node readable stream: https://nodejs.org/api/stream.html#stream_readable_streams
  */
-export class ReadableWeToNodeStream extends Readable {
+export class ReadableWebToNodeStream extends Readable {
 
   public bytesRead: number = 0;
   public released = false;


### PR DESCRIPTION
Rename `ReadableWeToNodeStream` to `ReadableWebToNodeStream` 😓.