### PR TITLE
Include es2015 & dom as default set of type definitions

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "lib": [
+      "es2015",
+      "dom"
+    ]
   },
   "exclude": [
     "test.ts",


### PR DESCRIPTION
Include [es2015](https://github.com/microsoft/TypeScript/blob/master/lib/lib.es2015.core.d.ts) & [dom](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts) as default set of type definitions matching browser environment.