### PR TITLE
Propagate `stream.readable.destroy()`

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,5 @@
   "watch-files": ["lib/**/*.ts", "test/**/*.ts"],
   "spec": ["test/*.ts"],
   "loader": ["ts-node/esm"],
-  "extensions": ["ts", "tsx"],
-  "timeout": 40000
+  "extensions": ["ts", "tsx"]
 }

--- a/README.md
+++ b/README.md
@@ -58,15 +58,11 @@ For TypeScript / CommonJS projects, not using Node.js ≥ 22, check [load-esm](h
 
 ## API
 
-**constructor(stream: ReadableStream): Promise<void>**
+**constructor(stream: ReadableStream, options): Promise<void>**
 
-`stream: ReadableStream`: the [Web-API readable stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader).
-
-**close(): Promise<void>**
-Will cancel close the Readable-node stream, and will release Web-API-readable-stream.
-
-**waitForReadToComplete(): Promise<void>**
-If there is no unresolved read call to Web-API Readable​Stream immediately returns, otherwise it will wait until the read is resolved.
+- `stream: ReadableStream`: the [Web-API readable stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader).
+- `options?: {propagateDestroy: boolean}`
+  - `propagateDestroy`, default value is `false`, if set to `true`, will also cancel the _stream_ when the Node.js Readable is destroyed. 
 
 ## Licence
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -58,6 +58,9 @@
 				"rules": {
 					"correctness": {
 						"noNodejsModules": "off"
+					},
+					"suspicious": {
+						"noExplicitAny": "off"
 					}
 				}
 			}

--- a/lib/default.ts
+++ b/lib/default.ts
@@ -1,5 +1,7 @@
 import { Readable } from 'readable-stream'; // Userland Readable
-import { CommonReadableWebToNodeStream } from './common.js';
+import { CommonReadableWebToNodeStream, type ReadableWebToNodeStreamOptions } from './common.js';
+
+export type { ReadableWebToNodeStreamOptions } from './common.js';
 
 /**
  * Converts a Web-API stream into Node stream.Readable class
@@ -12,12 +14,12 @@ export class ReadableWebToNodeStream extends Readable {
   private converter: CommonReadableWebToNodeStream;
 
   /**
-   *
    * @param stream ReadableStream: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+   * @param options Options: `{propagateDestroy: boolean}`
    */
-  constructor(stream: ReadableStream | ReadableStream<Uint8Array>) {
+  constructor(stream: ReadableStream | ReadableStream<Uint8Array>, options?: ReadableWebToNodeStreamOptions) {
     super();
-    this.converter = new CommonReadableWebToNodeStream(stream);
+    this.converter = new CommonReadableWebToNodeStream(stream, options);
   }
 
   /**
@@ -30,10 +32,8 @@ export class ReadableWebToNodeStream extends Readable {
     this.converter.read(this);
   }
 
-  /**
-   * Close wrapper
-   */
-  public async close(): Promise<void> {
-    await this.converter.close();
+  _destroy(error: Error | null, callback: (error?: Error | null) => void) {
+    this.converter.destroy(error, callback);
   }
+
 }

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -1,5 +1,7 @@
 import { Readable } from 'node:stream'; // Node.js dependency
-import { CommonReadableWebToNodeStream } from './common.js';
+import { CommonReadableWebToNodeStream, type ReadableWebToNodeStreamOptions } from './common.js';
+
+export type { ReadableWebToNodeStreamOptions } from './common.js';
 
 /**
  * Converts a Web-API stream into Node stream.Readable class
@@ -14,10 +16,11 @@ export class ReadableWebToNodeStream extends Readable {
   /**
    *
    * @param stream ReadableStream: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+   * @param options Options: `{propagateDestroy: boolean}`
    */
-  constructor(stream: ReadableStream | ReadableStream<Uint8Array>) {
+  constructor(stream: ReadableStream | ReadableStream<Uint8Array>, options?: ReadableWebToNodeStreamOptions) {
     super();
-    this.converter = new CommonReadableWebToNodeStream(stream);
+    this.converter = new CommonReadableWebToNodeStream(stream, options);
   }
 
   /**
@@ -30,10 +33,8 @@ export class ReadableWebToNodeStream extends Readable {
     this.converter.read(this);
   }
 
-  /**
-   * Close wrapper
-   */
-  public async close(): Promise<void> {
-    await this.converter.close();
+  _destroy(error: Error | null, callback: (error?: Error | null) => void) {
+    this.converter.destroy(error, callback);
   }
+
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,68 @@
+import type {Readable} from 'node:stream';
+
+export class MockedReadableStream {
+  public pullRequest = false;
+  public cancelled = false;
+  public controller?: ReadableStreamDefaultController<Uint8Array>;
+  public stream: ReadableStream<Uint8Array>;
+
+  constructor() {
+    this.stream = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        this.controller = controller;
+      },
+      pull: (controller) => {
+        this.controller = controller;
+        this.pullRequest = true;
+      },
+      cancel: (reason: any) => {
+        this.cancelled = true;
+      },
+    });
+  }
+}
+
+export class Deferred<T> {
+  public promise: Promise<T>;
+  public resolve!: (value: T | PromiseLike<T>) => void;
+  public reject!: (reason?: any) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+export class NodeReadableListener {
+
+  public chunks: Uint8Array[] = [];
+  public errors: Error[] = [];
+  public ended = 0;
+  public closed = 0;
+
+  private waitUntilClosedDeferred = new Deferred<void>();
+
+  public constructor(nodeReadable: Readable) {
+    nodeReadable.on('data', chunk => {
+      this.chunks.push(chunk);
+    });
+    nodeReadable.on('error', error => {
+      this.errors.push(error);
+      this.waitUntilClosedDeferred.reject(error);
+    });
+    nodeReadable.on('end', () => {
+      ++this.ended;
+    });
+    nodeReadable.on('close', () => {
+      ++this.closed;
+      this.waitUntilClosedDeferred.resolve();
+    });
+  }
+
+  public waitUntilClosed(): Promise<void> {
+    return this.waitUntilClosedDeferred.promise;
+  }
+
+}


### PR DESCRIPTION
Release Reader on [Web API ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) upon [stream.Readable.destroy](https://nodejs.org/api/stream.html#readabledestroyerror).